### PR TITLE
Disable mnemonic shuffling in confirmation

### DIFF
--- a/src/components/Mnemonic.js
+++ b/src/components/Mnemonic.js
@@ -245,16 +245,13 @@ const Confirm = styled(
 				if(!length){
 					onNoPhrase()
 				}else{
-					const words =
-						phraseSplit.map((word, i) => {
-							return {
-								index: i+1,
-								word: word,
-								correct: false
-							}
-						})
-
-					setWords(words)
+					setWords(phraseSplit.map((word, i) => {
+						return {
+							index: i+1,
+							word: word,
+							correct: false
+						}
+					}))
 
 					onChange({
 						confirmed: 0,

--- a/src/components/Mnemonic.js
+++ b/src/components/Mnemonic.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components'
-import { shuffle } from 'lodash'
 import { Button } from '@components'
 import { ReactComponent as IconRefresh } from '@assets/refresh.svg';
 import { ReactComponent as IconCheck } from '@assets/check.svg';
@@ -246,7 +245,7 @@ const Confirm = styled(
 				if(!length){
 					onNoPhrase()
 				}else{
-					const shuffled = shuffle(
+					const words =
 						phraseSplit.map((word, i) => {
 							return {
 								index: i+1,
@@ -254,9 +253,8 @@ const Confirm = styled(
 								correct: false
 							}
 						})
-					)
 
-					setWords(shuffled)
+					setWords(words)
 
 					onChange({
 						confirmed: 0,


### PR DESCRIPTION
My first PR :tada::tada::tada: 

In an effort to get across the codebase I disabled the mnemonic shuffling. I'm not sure it's worth the trouble for the user. Perhaps I'm missing something, though :)